### PR TITLE
Update remote input sender

### DIFF
--- a/Editor/RemoteInputModuleEditor.cs
+++ b/Editor/RemoteInputModuleEditor.cs
@@ -8,20 +8,38 @@ namespace Futurus.RemoteInput.Editor
     {
         RemoteInputModule _targetObject;
 
+        int _raycastersCount = -1;
+        string _raycasterNames = "";
+
         private void OnEnable()
         {
             _targetObject = serializedObject.targetObject as RemoteInputModule;
+            _raycastersCount = -1;
         }
         public override void OnInspectorGUI()
         {
             if (!_targetObject)
                 return;
 
+            UpdateRaycasters(RemoteInputRaycaster.AllRaycasters.Count);
+
             DrawDefaultInspector();
             EditorGUI.BeginDisabledGroup(!Application.isPlaying);
-            GUILayout.Label($"Raycasters: {RemoteInputRaycaster.AllRaycasters.Count}");
             GUILayout.Label($"Providers: {_targetObject.ProviderCount}");
+            GUILayout.Label($"Raycasters: {RemoteInputRaycaster.AllRaycasters.Count}");
+            GUILayout.Label(_raycasterNames);
             EditorGUI.EndDisabledGroup();
+        }
+
+        void UpdateRaycasters(int newCount)
+        {
+            if (_raycastersCount == newCount) return;
+            _raycastersCount = newCount;
+            _raycasterNames = "Active raycasters: ";
+            foreach (var raycaster in RemoteInput.RemoteInputRaycaster.AllRaycasters)
+            {
+                _raycasterNames += "\n  " + raycaster.name;
+            }
         }
     }
 }

--- a/Runtime/RemoteInputRaycaster.cs
+++ b/Runtime/RemoteInputRaycaster.cs
@@ -46,14 +46,14 @@ namespace Futurus.RemoteInput
         #endregion
 
         #region Unity
-        protected override void Awake()
+        protected override void OnEnable()
         {
-            base.Awake();
+            base.OnEnable();
             AllRaycasters.Add(this);
         }
-        protected override void OnDestroy()
+        protected override void OnDisable()
         {
-            base.OnDestroy();
+            base.OnDisable();
             AllRaycasters.Remove(this);
         }
 #if UNITY_EDITOR

--- a/Runtime/RemoteInputSender.cs
+++ b/Runtime/RemoteInputSender.cs
@@ -52,6 +52,7 @@ namespace Futurus.RemoteInput
                 }
             }
         }
+        public bool Validated { get; protected set; }
 
         /// <summary>
         /// Toggles whether this RemoteInputProvider is selecting 
@@ -66,6 +67,7 @@ namespace Futurus.RemoteInput
         {
             ValidateProvider();
             ValidatePresentation();
+            _cachedRemoteInputModule?.Register(this);
         }
         protected virtual void OnDisable()
         {
@@ -80,7 +82,6 @@ namespace Futurus.RemoteInput
             _cachedEventData = _cachedRemoteInputModule.GetRemoteInputEventData(this);
             UpdateLine(_cachedEventData.LastRaycastResult);
             _cachedEventData.UpdateFromRemote();
-            if (ValidatePresentation())
                 UpdatePresentation();
         }
         protected virtual void OnDrawGizmos()
@@ -110,9 +111,11 @@ namespace Futurus.RemoteInput
         #region Internal
         bool ValidateProvider()
         {
+            if (Validated) return true;
             _cachedRemoteInputModule = (_cachedRemoteInputModule != null) ? _cachedRemoteInputModule : EventSystem.current.currentInputModule as RemoteInputModule;
             _cachedRemoteInputModule?.SetRegistration(this, true);
-            return _cachedRemoteInputModule != null;
+            Validated = _cachedRemoteInputModule != null;
+            return Validated;
         }
         bool ValidatePresentation()
         {

--- a/Runtime/RemoteInputSender.cs
+++ b/Runtime/RemoteInputSender.cs
@@ -151,11 +151,7 @@ namespace Futurus.RemoteInput
             if (result.isValid)
             {
                 _endpoint = result.worldPosition;
-                // result.worldNormal doesn't work properly, seems to always have the normal face directly up
-                // instead, we calculate the normal via the inverse of the forward vector on what we hit. Unity UI elements
-                // by default face away from the user, so we use that assumption to find the true "normal"
-                // If you use a curved UI canvas this likely will not work 
-                _endpointNormal = result.gameObject.transform.forward * -1;
+                _endpointNormal = result.worldNormal;
             }
             else /// not raycast hit
             {
@@ -165,7 +161,7 @@ namespace Futurus.RemoteInput
                     return;
                 }
                 _endpoint = transform.position + transform.forward * _maxLength;
-                _endpointNormal = (transform.position - _endpoint).normalized;
+                // _endpointNormal = (transform.position - _endpoint).normalized; // no need to calculate as its not drawn
             }
             DrawLine(true);
             _points[0] = transform.position;
@@ -180,7 +176,7 @@ namespace Futurus.RemoteInput
             if (_cursorMesh != null && _cursorMat != null)
             {
                 _cursorMat.color = _gradient.Evaluate(1);
-                var matrix = Matrix4x4.TRS(_points[1], Quaternion.Euler(_endpointNormal), Vector3.one * _cursorScale);
+                var matrix = Matrix4x4.TRS(_points[1], Quaternion.LookRotation(_endpointNormal), Vector3.one * _cursorScale);
                 Graphics.DrawMesh(_cursorMesh, matrix, _cursorMat, 0);
             }
         }

--- a/Runtime/RemoteInputSender.cs
+++ b/Runtime/RemoteInputSender.cs
@@ -8,30 +8,32 @@ namespace Futurus.RemoteInput
         const float MinLineWidth = 0.0001f;
 
         #region Inspector
+        [Header("Raycaster")]
         [SerializeField] protected float _maxLength = 100f;
         [SerializeField] protected bool _occlude;
         [SerializeField] protected LayerMask _occludeMask;
 
-        [Header("Presentation")]
+        [Header("Presentation - Line")]
         [SerializeField] protected bool _lineRendererAlwaysOn = false;
         [SerializeField] protected LineRenderer _lineRenderer = null;
         [SerializeField, Min(MinLineWidth)] protected float _lineWidth = 0.002f;
         [SerializeField] protected AnimationCurve _widthCurve = AnimationCurve.Linear(0f, 1f, 1f, 0f);
         [SerializeField] protected Gradient _gradient = new Gradient();
+        [Header("Presentation - Cursor")]
         [SerializeField] protected float _cursorScale = 0.1f;
         [SerializeField] protected Sprite _cursorSprite = null;
         #endregion
 
         #region Runtime
-        Mesh _cursorMesh = null;
-        Material _cursorMat = null;
-        bool _selectDown = false;
-        bool _hasHit = false;
-        Vector3 _endpoint = Vector3.zero;
-        Vector3 _endpointNormal = Vector3.zero;
-        Vector3[] _points = new Vector3[2];
-        RemoteInputModule _cachedRemoteInputModule;
-        RemoteInputEventData _cachedEventData;
+        protected Mesh _cursorMesh = null;
+        protected Material _cursorMat = null;
+        protected bool _selectDown = false;
+        protected bool _hasHit = false;
+        protected Vector3 _endpoint = Vector3.zero;
+        protected Vector3 _endpointNormal = Vector3.zero;
+        protected Vector3[] _points = new Vector3[2];
+        protected RemoteInputModule _cachedRemoteInputModule;
+        protected RemoteInputEventData _cachedEventData;
         #endregion
 
         #region Public
@@ -111,7 +113,7 @@ namespace Futurus.RemoteInput
         #endregion
 
         #region Internal
-        bool ValidateProvider()
+        protected bool ValidateProvider()
         {
             if (Validated) return true;
             _cachedRemoteInputModule = (_cachedRemoteInputModule != null) ? _cachedRemoteInputModule : EventSystem.current.currentInputModule as RemoteInputModule;
@@ -119,7 +121,7 @@ namespace Futurus.RemoteInput
             Validated = _cachedRemoteInputModule != null;
             return Validated;
         }
-        bool ValidatePresentation()
+        protected bool ValidatePresentation()
         {
             _lineRenderer = (_lineRenderer != null) ? _lineRenderer : GetComponent<LineRenderer>();
             if (_lineRenderer == null)
@@ -145,7 +147,7 @@ namespace Futurus.RemoteInput
             return true;
         }
         
-        void UpdateLine(RaycastResult result)
+        protected void UpdateLine(RaycastResult result)
         {
             _hasHit = result.isValid;
             if (result.isValid)
@@ -168,7 +170,7 @@ namespace Futurus.RemoteInput
             _points[_points.Length - 1] = _endpoint;
             _lineRenderer.SetPositions(_points);
         }
-        void DrawCursor()
+        protected void DrawCursor()
         {
             if (!ValidRaycastHit)
                 return;
@@ -180,7 +182,7 @@ namespace Futurus.RemoteInput
                 Graphics.DrawMesh(_cursorMesh, matrix, _cursorMat, 0);
             }
         }
-        void DrawLine(bool toEnable)
+        protected void DrawLine(bool toEnable)
         {
             if (_lineRenderer.enabled != toEnable)
                 _lineRenderer.enabled = toEnable;

--- a/Runtime/RemoteInputSender.cs
+++ b/Runtime/RemoteInputSender.cs
@@ -84,9 +84,11 @@ namespace Futurus.RemoteInput
             if (!ValidateProvider())
                 return;
             _cachedEventData = _cachedRemoteInputModule.GetRemoteInputEventData(this);
+            _hasHit = _cachedEventData.LastRaycastResult.isValid;
             UpdateLine(_cachedEventData.LastRaycastResult);
-            _cachedEventData.UpdateFromRemote();
             DrawCursor();
+
+            _cachedEventData.UpdateFromRemote();
         }
         protected virtual void OnDrawGizmos()
         {
@@ -149,7 +151,6 @@ namespace Futurus.RemoteInput
         
         protected void UpdateLine(RaycastResult result)
         {
-            _hasHit = result.isValid;
             if (result.isValid)
             {
                 _endpoint = result.worldPosition;
@@ -178,7 +179,7 @@ namespace Futurus.RemoteInput
             if (_cursorMesh != null && _cursorMat != null)
             {
                 _cursorMat.color = _gradient.Evaluate(1);
-                var matrix = Matrix4x4.TRS(_points[1], Quaternion.LookRotation(_endpointNormal), Vector3.one * _cursorScale);
+                var matrix = Matrix4x4.TRS(_endpoint, Quaternion.LookRotation(_endpointNormal), Vector3.one * _cursorScale);
                 Graphics.DrawMesh(_cursorMesh, matrix, _cursorMat, 0);
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.futurus.remoteinput",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "displayName": "Futurus Remote Input",
   "description": "A Unity Package for interacting world-space UI from a world-space remote, by Futurus",
   "unity": "2020.3",


### PR DESCRIPTION
#### RemoteInputSender

- Fixed the cursor's normal
- Changed a lot of vars and functions to be `protected` so it can be extended by `LoamRemoteInputSender`
- Add flag `_lineRendererAlwaysOn` (render line regardless of raycast hit)
- Cache ValidateProvider result using bool `Validated` since its called per FixedUpdate
- Separate out `UpdateLine` and `DrawCursor` in UpdatePresentation()
  - as in the case of `LoamRemoteInputSender`, the line is always drawn but not the cursor, which is only on hand that's in-focus

#### RemoteInputModuleEditor
print out the names of each raycaster to help debug

#### RemoteInputRaycaster
 - Changed self-subscribing to `AllRaycasters` from Awake/OnDestroy to OnEnable/OnDisable
 - This was causing trouble detecting active raycaster in `PlayerHand_OnRaycastersChanged`
   - I made other changes so it's no longer necessary. I can revert this change back if it makes more sense that way
   - (see Loam.UIMenuController.ToggleMenuControlsActiveState)
